### PR TITLE
`TrustedHostsNetworkResolver` - parse port from "host" directive of RFC header as well

### DIFF
--- a/src/TrustedHostsNetworkResolver.php
+++ b/src/TrustedHostsNetworkResolver.php
@@ -641,11 +641,22 @@ class TrustedHostsNetworkResolver implements MiddlewareInterface
                 }
             }
 
+            $host = $directiveMap['host'] ?? null;
+            $port = null;
+            if ($host !== null) {
+                /** @infection-ignore-all IncrementInteger */
+                $hostParts = explode(':', $host, 2);
+                $host = $hostParts[0];
+
+                if (isset($hostParts[1])) {
+                    $port = $hostParts[1];
+                }
+            }
+
             $wasIpValidated = false;
 
             if ($this->checkIpIdentifier($directiveMap['for'])) {
                 $ip = null;
-                $port = null;
                 $ipIdentifier = $directiveMap['for'];
             } else {
                 if (preg_match($forPattern, $directiveMap['for'], $matches) === 0) {
@@ -673,14 +684,17 @@ class TrustedHostsNetworkResolver implements MiddlewareInterface
                     }
                 }
 
-                $port = $matches['port'] ?? null;
+                if ($port === null && isset($matches['port'])) {
+                    $port = $matches['port'];
+                }
+
                 $ipIdentifier = null;
             }
 
             $proxies[] = $this->getConnectionChainItem(
                 ip: $ip,
                 protocol: $directiveMap['proto'] ?? null,
-                host: $directiveMap['host'] ?? null,
+                host: $host,
                 port: $port,
                 ipIdentifier: $ipIdentifier,
                 validateIp: !$wasIpValidated,

--- a/tests/TrustedHostsNetworkResolver/ProcessTest.php
+++ b/tests/TrustedHostsNetworkResolver/ProcessTest.php
@@ -1176,6 +1176,47 @@ final class ProcessTest extends TestCase
                     'port' => 8082,
                 ],
             ],
+            yield 'RFC header, IP related data, port in host, priority over port in IP' => [
+                $this
+                    ->createMiddleware()
+                    ->withTrustedIps(['8.8.8.8', '2.2.2.2', '18.18.18.18'])
+                    ->withConnectionChainItemsAttribute('connectionChainItems'),
+                $this->createRequest(
+                    headers: [
+                        'Forwarded' => [
+                            'for="9.9.9.9:8083";proto=http;host=example3.com',
+                            'for="5.5.5.5:8082";proto=https;host="example2.com:8085"',
+                            'for="2.2.2.2";proto=http;host="example1.com:8084"',
+                        ],
+                    ],
+                    serverParams: ['REMOTE_ADDR' => '18.18.18.18'],
+                ),
+                [
+                    'requestClientIp' => '5.5.5.5',
+                    'connectionChainItemsAttribute' => [
+                        'connectionChainItems',
+                        [
+                            [
+                                'ip' => '18.18.18.18',
+                                'protocol' => null,
+                                'host' => null,
+                                'port' => null,
+                                'ipIdentifier' => null,
+                            ],
+                            [
+                                'ip' => '2.2.2.2',
+                                'protocol' => 'http',
+                                'host' => 'example1.com',
+                                'port' => 8084,
+                                'ipIdentifier' => null,
+                            ],
+                        ],
+                    ],
+                    'protocol' => 'https',
+                    'host' => 'example2.com',
+                    'port' => 8085,
+                ],
+            ],
         ];
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ❌
